### PR TITLE
add setInterval in start function

### DIFF
--- a/MMM-PGHBus.js
+++ b/MMM-PGHBus.js
@@ -23,7 +23,9 @@ Module.register("MMM-PGHBus", {
 
         this.busStopPairDict = {};
         this.bus = null;
-        this.getBuses();       // set intervals for bus schedule to update
+        setInterval(() => {
+            this.getBuses();       // set intervals for bus schedule to update
+        }, this.config.updateInterval);
     },
 
 


### PR DESCRIPTION
This allows the module to update properly using the updateInterval parameter. Previously it would update once when MM2 started, but there was no method prompting another socket notification to be sent (or any use of the updateInterval parameter in the rest of the code, as far as I can tell).